### PR TITLE
Fix the null userImage issue

### DIFF
--- a/src/components/CommentEditor.vue
+++ b/src/components/CommentEditor.vue
@@ -23,7 +23,7 @@ export default {
   props: {
     slug: { type: String, required: true },
     content: { type: String, required: false },
-    userImage: { type: String, required: true }
+    userImage: { type: String, required: false }
   },
   data () {
     return {


### PR DESCRIPTION
An error appear if the user doesn't have a picture.

<img width="703" alt="null-image" src="https://user-images.githubusercontent.com/4519374/31588593-b5a5feb6-b1f4-11e7-9904-27fff75f6ed3.png">
